### PR TITLE
Update com.fasterxml.jackson.core:jackson-core to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-annotations-version>1.5.22</swagger-annotations-version>
         <resteasy-version>6.2.4.Final</resteasy-version>
-        <jackson-version>2.14.3</jackson-version>
+        <jackson-version>2.15.0</jackson-version>
         <jackson-databind-version>2.14.3</jackson-databind-version>
         <jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
         <threetenbp-version>2.15.2</threetenbp-version>


### PR DESCRIPTION
Keep your dependencies up-to-date. This makes it easier to fix existing vulnerabilities and to more quickly identify and fix newly disclosed vulnerabilities when they affect your project.

Issue related to this dependabot alert https://github.com/zendesk/sunshine-conversations-java/security/dependabot/10